### PR TITLE
fix: openEO.tif path

### DIFF
--- a/DataAccess/OpenEO_tuto/Tuto_3__Cloud_classification.ipynb
+++ b/DataAccess/OpenEO_tuto/Tuto_3__Cloud_classification.ipynb
@@ -2238,7 +2238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": null,
    "id": "3e8f3182-bb88-4837-b834-4b5eb1533bad",
    "metadata": {},
    "outputs": [
@@ -2254,7 +2254,7 @@
     }
    ],
    "source": [
-    "predicted_test = rioxarray.open_rasterio('openEO.tif')\n",
+    "predicted_test = rioxarray.open_rasterio('output/openEO.tif')\n",
     "ref_test = rioxarray.open_rasterio('input/cloud_test.tiff')\n",
     "\n",
     "fig, axes = plt.subplots(ncols=3, figsize=(10, 3), dpi=100, sharey=True, sharex=True)\n",


### PR DESCRIPTION
When testing this notebook after the missing geojson fix, it resulted in an error due to the openEO.tif file that was missing but it was just a path error. This PR fixes the issue